### PR TITLE
微服务应用管理端口修改无效的jira

### DIFF
--- a/generators/create-gateway/templates/gateway/kubernetes/${PROJECT_NAME}.yml
+++ b/generators/create-gateway/templates/gateway/kubernetes/${PROJECT_NAME}.yml
@@ -75,8 +75,11 @@ metadata:
 data:
   application.yml: |-
     #Actuator 配置
-    management:
+    server:
       port: 8080
+    management:
+      server:
+        port: 8080
       endpoint:
         health:
           probes:
@@ -96,6 +99,8 @@ data:
       #调用链配置
       zipkin:
         base-url: http://<%= JAEGER_HOST  || "#请输入 Jaeger 主机名" %>:<%= JAEGER_PORT || "#请输入 Jaeger 端口号" %>/
+        service:
+          name: <%= PROJECT_NAME %>.<%= K8S_NAMESPACE || "#请输入 命名空间名称" %>
     <%_ } -%>
 ---
 apiVersion: apps/v1
@@ -129,6 +134,11 @@ spec:
       containers:
         - image: <%= DOCKER_IMAGE || "#请输入镜像" %>
           imagePullPolicy: Always
+          env:
+          - name: MICRO_SERVICE_NAME
+            value: <%= PROJECT_NAME %>
+          - name: KUBERNETES_NAMESPACE
+            value: <%= K8S_NAMESPACE || "#请输入 命名空间名称" %>
           name: <%= PROJECT_NAME %>
           <%_ if (CONFIG_SERVER_TYPE == 'K8S') { -%>
           volumeMounts:

--- a/generators/create-gateway/templates/gateway/pom.xml
+++ b/generators/create-gateway/templates/gateway/pom.xml
@@ -23,13 +23,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway</artifactId>
-            <version>2.2.6.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
-            <version>2.2.6.RELEASE</version>
         </dependency>
 
         <dependency>
@@ -37,14 +35,6 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
             <version>1.6.1</version>
         </dependency>
-
-<%if (circuitBreakerEnabled || rateLimitEnabled) { -%>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
-            <version>1.0.4.RELEASE</version>
-		</dependency>
-<% } -%>
 <%if (configServerEnabled && configServerType == 'CONSUL') { -%>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -55,7 +45,6 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-all</artifactId>
-            <version>1.1.7.RELEASE</version>
         </dependency>
 <% } -%>
 <%if (discoveryServerType == 'CONSUL') { -%>
@@ -67,39 +56,34 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>2.2.6.RELEASE</version>
         </dependency>
 
 <%if (tracingEnabled) { -%>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-zipkin</artifactId>
-            <version>2.2.6.RELEASE</version>
         </dependency>
 <% } -%>
 
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
+            <version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
-            <version>2.3.5.RELEASE</version>
         </dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-            <version>1.18.18</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-            <version>2.3.5.RELEASE</version>
             <scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/generators/create-gateway/templates/gateway/pom.xml
+++ b/generators/create-gateway/templates/gateway/pom.xml
@@ -23,17 +23,26 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway</artifactId>
-		</dependency>
+            <version>2.2.6.RELEASE</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
+            <version>2.2.6.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.6.1</version>
         </dependency>
 
 <%if (circuitBreakerEnabled || rateLimitEnabled) { -%>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
+            <version>1.0.4.RELEASE</version>
 		</dependency>
 <% } -%>
 <%if (configServerEnabled && configServerType == 'CONSUL') { -%>
@@ -46,6 +55,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-all</artifactId>
+            <version>1.1.7.RELEASE</version>
         </dependency>
 <% } -%>
 <%if (discoveryServerType == 'CONSUL') { -%>
@@ -57,17 +67,14 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-		</dependency>
+            <version>2.2.6.RELEASE</version>
+        </dependency>
 
 <%if (tracingEnabled) { -%>
-<!--		<dependency>-->
-<!--			<groupId>io.opentracing.contrib</groupId>-->
-<!--			<artifactId>opentracing-spring-jaeger-cloud-starter</artifactId>-->
-<!--			<version>3.2.2</version>-->
-<!--		</dependency>-->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-zipkin</artifactId>
+            <version>2.2.6.RELEASE</version>
         </dependency>
 <% } -%>
 
@@ -80,18 +87,20 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
+            <version>2.3.5.RELEASE</version>
+        </dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+            <version>1.18.18</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+            <version>2.3.5.RELEASE</version>
+            <scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.junit.vintage</groupId>

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Request.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Request.java
@@ -1,0 +1,9 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+
+@Data
+public class <%= upperProjectName %>Request {
+    private String path;
+    private String method;
+}

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RequestWrapper.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RequestWrapper.java
@@ -1,0 +1,10 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+
+@Data
+public class <%= upperProjectName %>RequestWrapper {
+
+    private <%= upperProjectName %>Request request;
+
+}

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rule.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rule.java
@@ -1,0 +1,14 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+
+@Data
+public class <%= upperProjectName %>Rule {
+    private String value;
+    private String condition;
+    public static final <%= upperProjectName %>Rule UNKNOWN;
+    static  {
+        UNKNOWN = new <%= upperProjectName %>Rule();
+        UNKNOWN.setValue("unknown");
+    }
+}

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rules.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rules.java
@@ -1,0 +1,14 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Data
+@ConfigurationProperties()
+public class <%= upperProjectName %>Rules {
+    private List<<%= upperProjectName %>Rule> classification;
+}

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RulesParser.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RulesParser.java
@@ -1,0 +1,65 @@
+package <%= packageName %>.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.http.HttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.server.ServerWebExchange;
+import java.util.Objects;
+
+@Component
+public class <%= upperProjectName %>RulesParser {
+    private static final Logger log = LoggerFactory.getLogger(<%= upperProjectName %>RulesParser.class);
+
+    @Autowired
+    private <%= upperProjectName %>Rules rules;
+
+    public String parseClassification(ServerWebExchange exchange) {
+        if(Objects.isNull(rules) || Objects.isNull(rules.getClassification())) {
+            return <%= upperProjectName %>Rule.UNKNOWN.getValue();
+        }
+        <%= upperProjectName %>Request req = new <%= upperProjectName %>Request();
+        req.setMethod(exchange.getRequest().getMethod().name().toUpperCase());
+        req.setPath(exchange.getRequest().getPath().value());
+        return getRuleValue(req);
+    }
+
+    public String parseClassification(HttpRequest request) {
+        if(Objects.isNull(rules) || Objects.isNull(rules.getClassification())) {
+            return <%= upperProjectName %>Rule.UNKNOWN.getValue();
+        }
+        <%= upperProjectName %>Request req = new <%= upperProjectName %>Request();
+        req.setMethod(request.getMethod().name());
+        req.setPath(request.getURI().getPath());
+        return getRuleValue(req);
+    }
+    public String parseClassification(ClientRequest request) {
+        if(Objects.isNull(rules) || Objects.isNull(rules.getClassification())) {
+            return <%= upperProjectName %>Rule.UNKNOWN.getValue();
+        }
+        <%= upperProjectName %>Request req = new <%= upperProjectName %>Request();
+        req.setMethod(request.method().name());
+        req.setPath(request.url().getPath());
+        return getRuleValue(req);
+    }
+
+    private String getRuleValue(<%= upperProjectName %>Request req) {
+        <%= upperProjectName %>RequestWrapper model = new <%= upperProjectName %>RequestWrapper();
+        model.setRequest(req);
+        <%= upperProjectName %>Rule rule = rules.getClassification().stream()
+            .filter(r -> {
+                ExpressionParser parser = new SpelExpressionParser();
+                Expression exp = parser.parseExpression(r.getCondition());
+                return (Boolean) exp.getValue(model);
+            })
+            .findFirst()
+            .orElse(<%= upperProjectName %>Rule.UNKNOWN);
+        log.info("Got value {}", rule.getValue());
+        return rule.getValue();
+    }
+}

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}HeadersGlobalFilter.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}HeadersGlobalFilter.java
@@ -1,0 +1,38 @@
+package <%= packageName %>.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public class <%= upperProjectName %>HeadersGlobalFilter implements GlobalFilter, Ordered {
+
+    static final Logger logger = LoggerFactory.getLogger(<%= upperProjectName %>HeadersGlobalFilter.class);
+    @Autowired
+    <%= upperProjectName %>MetricTags metricTags;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        logger.info("Adding the client headers {} and {}", metricTags.getSourceServiceName(), metricTags.getSourceServiceNamespace());
+        String previousName = exchange.getRequest().getHeaders().getFirst("X-Client-Name");
+        String previousNamespace = exchange.getRequest().getHeaders().getFirst("X-Client-Namespace");
+        exchange.getRequest().mutate()
+            .header("X-Client-Name", metricTags.getSourceServiceName())
+            .header("X-Client-Namespace", metricTags.getSourceServiceNamespace())
+            .header(<%= upperProjectName %>MetricTags.GATEWAY_CLIENT_NAME, previousName)
+            .header(<%= upperProjectName %>MetricTags.GATEWAY_CLIENT_NAMESPACE, previousNamespace)
+            .build();
+        return chain.filter(exchange);
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}MetricTags.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}MetricTags.java
@@ -2,6 +2,8 @@ package <%= packageName %>.metrics;
 
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,4 +18,6 @@ public class <%= upperProjectName %>MetricTags {
     private String protocol = "http";
     @Value("${server.names}")
     private String appName;
+    public static final String GATEWAY_CLIENT_NAME = "X-Origin-Client-Name";
+    public static final String GATEWAY_CLIENT_NAMESPACE = "X-Origin-Client-Namespace";
 }

--- a/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}WebClientConfig.java
+++ b/generators/create-gateway/templates/gateway/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}WebClientConfig.java
@@ -1,0 +1,131 @@
+package <%= packageName %>.metrics;
+
+import org.springframework.boot.actuate.metrics.web.reactive.server.WebFluxTags;
+import org.springframework.boot.actuate.metrics.web.reactive.server.WebFluxTagsProvider;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.tagsprovider.GatewayTagsProvider;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.ServerWebExchange;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.util.Arrays;
+import java.util.Objects;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
+import org.springframework.cloud.gateway.route.Route;
+import reactor.core.publisher.Mono;
+import <%= packageName %>.metrics.<%= upperProjectName %>MetricTags;
+import <%= packageName %>.config.<%= upperProjectName %>RulesParser;
+
+@Configuration
+public class <%= upperProjectName %>WebClientConfig {
+
+    private static final String REQUEST_OPERATION = "request_operation";
+    private static Logger logger = LoggerFactory.getLogger(<%= upperProjectName %>WebClientConfig.class);
+    @Autowired
+    <%= upperProjectName %>MetricTags metricTags;
+    @Autowired
+    private <%= upperProjectName %>RulesParser parser;
+
+    //Client 端数据tag添加
+    @Bean
+    public GatewayTagsProvider gatewayTagsProvider(){
+        return new GatewayTagsProvider() {
+            @Override
+            public Tags apply(ServerWebExchange serverWebExchange) {
+
+                logger.info("gateway tags provider started");
+
+                String destinationService;
+                String destinationNamespace;
+                String clientName;
+                String statusString;
+                String statusCode;
+
+                Route route = serverWebExchange.getAttribute(GATEWAY_ROUTE_ATTR);
+                String host = route.getUri().getHost();
+
+                clientName = metricTags.getSourceServiceName();
+                statusString = Objects.requireNonNull(serverWebExchange.getResponse().getStatusCode()).toString();
+
+                logger.info("gateway tags provider host==== " + host);
+                logger.info("gateway tags provider statuscode");
+
+                if (statusString.contains(" ")){
+                    String[] statusStrings = statusString.split(" ");
+                    statusCode = statusStrings[0];
+                }else{
+                    statusCode = "default_unknow";
+                }
+
+                if(host.contains(".")){
+                    String[] hosts = host.split("\\.");
+                    destinationService = hosts[0];
+                    destinationNamespace = hosts[1];
+                } else {
+                    destinationService = "localhost".equalsIgnoreCase(host) ? metricTags.getSourceServiceName() : host;
+                    destinationNamespace = metricTags.getSourceServiceNamespace();
+                }
+
+                Tag dsTag = Tag.of("destination_service", destinationService);
+                Tag dnsTag = Tag.of("destination_namespace", destinationNamespace);
+                Tag clientNameTag = Tag.of("clientName", clientName);
+                Tag statusCodeTag = Tag.of("status", statusCode);
+                Tag servieNameTag = Tag.of("service", metricTags.getSourceServiceName());
+                Tag classification = Tag.of(REQUEST_OPERATION, parser.parseClassification(serverWebExchange));
+
+                return Tags.of(dsTag, dnsTag, clientNameTag, servieNameTag, statusCodeTag, classification);
+            }
+        };
+    }
+
+    //Server 端数据tag添加
+    @Bean
+    public WebFluxTagsProvider webFluxTagsProvider() {
+        return new WebFluxTagsProvider() {
+            @Override
+            public Iterable<Tag> httpRequestTags(ServerWebExchange exchange, Throwable exception) {
+
+                logger.info("webflux tags provider started");
+
+                String clientName;
+                String clientNamespace;
+
+                HttpHeaders httpHeadersClientName = exchange.getRequest().getHeaders();
+                clientName = httpHeadersClientName.getFirst(<%= upperProjectName %>MetricTags.GATEWAY_CLIENT_NAME);
+
+                HttpHeaders httpHeadersClientNameSpace = exchange.getRequest().getHeaders();
+                clientNamespace = httpHeadersClientNameSpace.getFirst(<%= upperProjectName %>MetricTags.GATEWAY_CLIENT_NAMESPACE);
+
+                String host = exchange.getRequest().getURI().getHost();
+
+                logger.info("webflux tags provider client name ==== " +  clientName);
+                logger.info("webflux tags provider client namespace ==== " +  clientNamespace);
+
+                Tag clientNameTag;
+                Tag clientNamespaceTag;
+                Tag servieNameTag = Tag.of("service", metricTags.getSourceServiceName());
+
+                if (clientName != null) {
+                    clientNameTag = Tag.of("client_name", clientName);
+                }else{
+                    clientNameTag = Tag.of("client_name", "default_unknown");
+                }
+
+                if (clientNamespace != null) {
+                    clientNamespaceTag = Tag.of("client_namespace", clientNamespace);
+                }else{
+                    clientNamespaceTag = Tag.of("client_namespace", "default_unknown");
+                }
+                return Arrays.asList(clientNameTag, clientNamespaceTag, servieNameTag,
+                    WebFluxTags.status(exchange), Tag.of(REQUEST_OPERATION, parser.parseClassification(exchange)));
+            }
+        };
+    }
+}

--- a/generators/create-gateway/templates/gateway/src/main/resources/bootstrap.yml
+++ b/generators/create-gateway/templates/gateway/src/main/resources/bootstrap.yml
@@ -1,3 +1,35 @@
+server:
+  port: 8080
+  names: ${MICRO_SERVICE_NAME}
+management:
+  server:
+    port: 8080
+  endpoint:
+    info:
+      enabled: true
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  metrics:
+    tags:
+      service: ${MICRO_SERVICE_NAME}
+      namespace: <%= K8S_NAMESPACE || "#请输入 命名空间名称" %>
+    distribution:
+      percentiles-histogram:
+        http:
+          server:
+            requests: true
+    web:
+      server:
+        request:
+          autotime:
+            percentiles: 0.5,0.95,0.99
+    enable:
+      jvm: false
 logging:
   level:
     reactor:
@@ -11,6 +43,15 @@ spring:
     #服务名称
     name: ${MICRO_SERVICE_NAME}
   cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+      metrics:
+        prefix: http_client
+    loadbalancer:
+      ribbon:
+        enabled: false
     <%_ if (CONFIG_SERVER_TYPE == 'CONSUL' || DISCOVERY_SERVER_TYPE == 'CONSUL') { -%>
     #Consul 配置
     consul:
@@ -51,4 +92,9 @@ spring:
           - name: ${MICRO_SERVICE_NAME}
       reload:
         enabled: true
+      service:
+        name: ${MICRO_SERVICE_NAME:default_unknown}
+        namespace: ${KUBERNETES_NAMESPACE:default_unknown}
+      discovery:
+        all-namespace: true
     <%_ } -%>

--- a/generators/create-service/templates/microservice/kubernetes/${PROJECT_NAME}.yml
+++ b/generators/create-service/templates/microservice/kubernetes/${PROJECT_NAME}.yml
@@ -80,8 +80,11 @@ metadata:
 data:
   application.yml: |-
     #Actuator 配置
-    management:
+    server:
       port: 8080
+    management:
+      server:
+        port: 8080
       endpoint:
         health:
           probes:
@@ -166,6 +169,8 @@ spec:
           imagePullPolicy: Always
           env:
           - name: SPRING_APPLICATION_NAME
+            value: <%= PROJECT_NAME %>
+          - name: MICRO_SERVICE_NAME
             value: <%= PROJECT_NAME %>
           - name: KUBERNETES_NAMESPACE
             value: <%= K8S_NAMESPACE || "#请输入 命名空间名称" %>

--- a/generators/create-service/templates/microservice/pom.xml
+++ b/generators/create-service/templates/microservice/pom.xml
@@ -23,20 +23,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-            <version>2.3.5.RELEASE</version>
 		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>2.3.5.RELEASE</version>
         </dependency>
-<%if (circuitBreakerEnabled || rateLimitEnabled) { -%>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
-            <version>1.0.4.RELEASE</version>
-		</dependency>
-<% } -%>
 <%if (configServerEnabled && configServerType == 'CONSUL') { -%>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -47,7 +38,6 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-all</artifactId>
-            <version>1.1.7.RELEASE</version>
         </dependency>
 <% } -%>
 <%if (discoveryServerType == 'CONSUL') { -%>
@@ -59,7 +49,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>2.2.6.RELEASE</version>
 		</dependency>
 
 <%if (messageQueueEnabled) { -%>
@@ -95,37 +84,32 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-sleuth</artifactId>
-            <version>2.2.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-zipkin</artifactId>
-            <version>2.2.6.RELEASE</version>
         </dependency>
 <% } -%>
 
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
+            <version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
-            <version>2.3.5.RELEASE</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-            <version>1.18.18</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-            <version>2.3.5.RELEASE</version>
             <scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/generators/create-service/templates/microservice/pom.xml
+++ b/generators/create-service/templates/microservice/pom.xml
@@ -23,15 +23,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+            <version>2.3.5.RELEASE</version>
 		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>2.3.5.RELEASE</version>
         </dependency>
 <%if (circuitBreakerEnabled || rateLimitEnabled) { -%>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+            <version>1.0.4.RELEASE</version>
 		</dependency>
 <% } -%>
 <%if (configServerEnabled && configServerType == 'CONSUL') { -%>
@@ -44,14 +47,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-all</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-kubernetes</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+            <version>1.1.7.RELEASE</version>
         </dependency>
 <% } -%>
 <%if (discoveryServerType == 'CONSUL') { -%>
@@ -63,6 +59,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
+            <version>2.2.6.RELEASE</version>
 		</dependency>
 
 <%if (messageQueueEnabled) { -%>
@@ -98,10 +95,12 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-sleuth</artifactId>
+            <version>2.2.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-zipkin</artifactId>
+            <version>2.2.6.RELEASE</version>
         </dependency>
 <% } -%>
 
@@ -114,18 +113,20 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
+            <version>2.3.5.RELEASE</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+            <version>1.18.18</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+            <version>2.3.5.RELEASE</version>
+            <scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.junit.vintage</groupId>

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Request.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Request.java
@@ -1,0 +1,9 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+
+@Data
+public class <%= upperProjectName %>Request {
+    private String path;
+    private String method;
+}

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RequestWrapper.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RequestWrapper.java
@@ -1,0 +1,10 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+
+@Data
+public class <%= upperProjectName %>RequestWrapper {
+
+    private <%= upperProjectName %>Request request;
+
+}

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rule.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rule.java
@@ -1,0 +1,14 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+
+@Data
+public class <%= upperProjectName %>Rule {
+    private String value;
+    private String condition;
+    public static final <%= upperProjectName %>Rule UNKNOWN;
+    static  {
+        UNKNOWN = new <%= upperProjectName %>Rule();
+        UNKNOWN.setValue("unknown");
+    }
+}

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rules.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}Rules.java
@@ -1,0 +1,14 @@
+package <%= packageName %>.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Data
+@ConfigurationProperties()
+public class <%= upperProjectName %>Rules {
+    private List<<%= upperProjectName %>Rule> classification;
+}

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RulesParser.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/config/${UPPER_PROJECT_NAME}RulesParser.java
@@ -1,0 +1,77 @@
+package <%= packageName %>.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.http.HttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.server.ServerWebExchange;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
+
+@Component
+public class <%= upperProjectName %>RulesParser {
+    private static final Logger log = LoggerFactory.getLogger(<%= upperProjectName %>RulesParser.class);
+
+    @Autowired
+    private <%= upperProjectName %>Rules rules;
+
+    public String parseClassification(HttpServletRequest request) {
+        if(Objects.isNull(rules) || Objects.isNull(rules.getClassification())) {
+            return <%= upperProjectName %>Rule.UNKNOWN.getValue();
+        }
+        <%= upperProjectName %>Request req = new <%= upperProjectName %>Request();
+        req.setMethod(request.getMethod());
+        req.setPath(request.getRequestURI());
+        return getRuleValue(req);
+    }
+
+    public String parseClassification(ServerWebExchange exchange) {
+        if(Objects.isNull(rules) || Objects.isNull(rules.getClassification())) {
+            return <%= upperProjectName %>Rule.UNKNOWN.getValue();
+        }
+        <%= upperProjectName %>Request req = new <%= upperProjectName %>Request();
+        req.setMethod(exchange.getRequest().getMethod().name().toUpperCase());
+        req.setPath(exchange.getRequest().getPath().value());
+        return getRuleValue(req);
+    }
+
+    public String parseClassification(HttpRequest request) {
+        if(Objects.isNull(rules) || Objects.isNull(rules.getClassification())) {
+            return <%= upperProjectName %>Rule.UNKNOWN.getValue();
+        }
+        <%= upperProjectName %>Request req = new <%= upperProjectName %>Request();
+        req.setMethod(request.getMethod().name());
+        req.setPath(request.getURI().getPath());
+        return getRuleValue(req);
+    }
+    public String parseClassification(ClientRequest request) {
+        if(Objects.isNull(rules) || Objects.isNull(rules.getClassification())) {
+            return <%= upperProjectName %>Rule.UNKNOWN.getValue();
+        }
+        <%= upperProjectName %>Request req = new <%= upperProjectName %>Request();
+        req.setMethod(request.method().name());
+        req.setPath(request.url().getPath());
+        return getRuleValue(req);
+    }
+
+    private String getRuleValue(<%= upperProjectName %>Request req) {
+        <%= upperProjectName %>RequestWrapper model = new <%= upperProjectName %>RequestWrapper();
+        model.setRequest(req);
+        <%= upperProjectName %>Rule rule = rules.getClassification().stream()
+            .filter(r -> {
+                ExpressionParser parser = new SpelExpressionParser();
+                Expression exp = parser.parseExpression(r.getCondition());
+                return (Boolean) exp.getValue(model);
+            })
+            .findFirst()
+            .orElse(<%= upperProjectName %>Rule.UNKNOWN);
+        log.info("Got value {}", rule.getValue());
+        return rule.getValue();
+    }
+}

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/controller/${UPPER_PROJECT_NAME}Controller.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/controller/${UPPER_PROJECT_NAME}Controller.java
@@ -32,9 +32,7 @@ import org.springframework.cloud.sleuth.SpanName;
 public class <%= upperProjectName %>Controller {
 
     <%_ if (tracingEnabled) { -%>
-
     private static Logger log = LoggerFactory.getLogger(<%= upperProjectName %>Controller.class);
-
     <%_ } -%>
 
     /**

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}TracingFilters.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}TracingFilters.java
@@ -14,7 +14,6 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component

--- a/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}WebClientConfig.java
+++ b/generators/create-service/templates/microservice/src/main/java/${PACKAGE_PATH}/metrics/${UPPER_PROJECT_NAME}WebClientConfig.java
@@ -1,21 +1,19 @@
 package <%= packageName %>.metrics;
 
 import <%= packageName %>.metrics.<%= upperProjectName %>MetricTags;
-
-import io.micrometer.core.instrument.MeterRegistry;
+import <%= packageName %>.config.<%= upperProjectName %>RulesParser;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import lombok.var;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.metrics.AutoTimer;
 import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTags;
 import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
-import org.springframework.boot.actuate.metrics.web.reactive.client.DefaultWebClientExchangeTagsProvider;
-import org.springframework.boot.actuate.metrics.web.reactive.client.MetricsWebClientFilterFunction;
 import org.springframework.boot.actuate.metrics.web.reactive.client.WebClientExchangeTags;
 import org.springframework.boot.actuate.metrics.web.reactive.client.WebClientExchangeTagsProvider;
+import org.springframework.boot.actuate.metrics.web.reactive.server.WebFluxTags;
+import org.springframework.boot.actuate.metrics.web.reactive.server.WebFluxTagsProvider;
 import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTags;
 import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -24,33 +22,42 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
-import org.springframework.util.StringUtils;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-
+import org.springframework.web.server.ServerWebExchange;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 @Configuration
 public class <%= upperProjectName %>WebClientConfig {
 
+    public static final String X_CLIENT_NAME = "X-Client-Name";
+    public static final String X_CLIENT_NAMESPACE = "X-Client-Namespace";
+    public static final String DESTINATION_SERVICE = "destination_service";
+    public static final String DESTINATION_NAMESPACE = "destination_namespace";
+    public static final String CLIENT_NAME_KEY = "client_name";
+    public static final String CLIENT_NAMESPACE_KEY = "client_namespace";
+    public static final String REQUEST_OPERATION = "request_operation";
     private static Logger logger = LoggerFactory.getLogger(<%= upperProjectName %>WebClientConfig.class);
+
     @Autowired
-    <%= upperProjectName %>MetricTags metricTags;
+    private <%= upperProjectName %>MetricTags metricTags;
+
+    @Autowired
+    private <%= upperProjectName %>RulesParser parser;
 
     @Bean
     public WebClient createWebClient(WebClient.Builder webClientBuilder) {
 
         WebClient webClient = webClientBuilder
-            .defaultHeader("X-Client-Name", metricTags.getSourceServiceName())
-            .defaultHeader("X-Client-Namespace", metricTags.getSourceServiceNamespace())
+            .defaultHeader(X_CLIENT_NAME, metricTags.getSourceServiceName())
+            .defaultHeader(X_CLIENT_NAMESPACE, metricTags.getSourceServiceNamespace())
             .build();
         return webClient;
     }
@@ -58,8 +65,8 @@ public class <%= upperProjectName %>WebClientConfig {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder templateBuilder) {
         return templateBuilder.requestFactory(OkHttp3ClientHttpRequestFactory::new)
-            .defaultHeader("X-Client-Name", metricTags.getSourceServiceName())
-            .defaultHeader("X-Client-Namespace", metricTags.getSourceServiceNamespace())
+            .defaultHeader(X_CLIENT_NAME, metricTags.getSourceServiceName())
+            .defaultHeader(X_CLIENT_NAMESPACE, metricTags.getSourceServiceNamespace())
             .build();
     }
 
@@ -68,16 +75,19 @@ public class <%= upperProjectName %>WebClientConfig {
         return new WebMvcTagsProvider() {
             @Override
             public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable exception) {
-                String clientName = request.getHeader("X-Client-Name");
-                String clientNamespace = request.getHeader("X-Client-Namespace");
+                String clientName = request.getHeader(X_CLIENT_NAME);
+                String clientNamespace = request.getHeader(X_CLIENT_NAMESPACE);
                 Tags tags = Tags.of(WebMvcTags.method(request),
                     WebMvcTags.exception(exception), WebMvcTags.status(response), WebMvcTags.outcome(response));
                 if(io.micrometer.core.instrument.util.StringUtils.isNotEmpty(clientName)) {
-                    tags = tags.and(Tag.of("client_name", clientName));
+                    tags = tags.and(Tag.of(CLIENT_NAME_KEY, clientName));
                 }
                 if(io.micrometer.core.instrument.util.StringUtils.isNotEmpty(clientNamespace)) {
-                    tags = tags.and(Tag.of("client_namespace", clientNamespace));
+                    tags = tags.and(Tag.of(CLIENT_NAMESPACE_KEY, clientNamespace));
                 }
+                tags = tags.and(Tag.of(REQUEST_OPERATION, parser.parseClassification(request)));
+                logger.info("Adding metrics tag of request_operation");
+
                 return tags;
             }
 
@@ -87,6 +97,30 @@ public class <%= upperProjectName %>WebClientConfig {
             }
         };
     }
+
+    @Bean
+    public WebFluxTagsProvider webFluxTagsProvider() {
+        return new WebFluxTagsProvider() {
+        @Override
+            public Iterable<Tag> httpRequestTags(ServerWebExchange exchange, Throwable ex) {
+            ServerHttpRequest request = exchange.getRequest();
+            String clientName = request.getHeaders().getFirst(X_CLIENT_NAME);
+            String clientNamespace = request.getHeaders().getFirst(X_CLIENT_NAMESPACE);
+            Tags tags = Tags.of(WebFluxTags.method(exchange),
+            WebFluxTags.exception(ex), WebFluxTags.status(exchange), WebFluxTags.outcome(exchange));
+            if(io.micrometer.core.instrument.util.StringUtils.isNotEmpty(clientName)) {
+                tags = tags.and(Tag.of(CLIENT_NAME_KEY, clientName));
+            }
+            if(io.micrometer.core.instrument.util.StringUtils.isNotEmpty(clientNamespace)) {
+                tags = tags.and(Tag.of(CLIENT_NAMESPACE_KEY, clientNamespace));
+            }
+            tags = tags.and(Tag.of(REQUEST_OPERATION, parser.parseClassification(exchange)));
+            logger.info("Adding metrics tag of request_operation for Reactive");
+            return tags;
+            }
+        };
+    }
+
 
     @Bean
     public RestTemplateExchangeTagsProvider restTemplateExchangeTagsProvider() {
@@ -105,10 +139,11 @@ public class <%= upperProjectName %>WebClientConfig {
                     destinationService = "localhost".equalsIgnoreCase(host) ? metricTags.getSourceServiceName() : host;
                     destinationNamespace = metricTags.getSourceServiceNamespace();
                 }
-                Tag dsTag = Tag.of("destination_service", destinationService);
-                Tag dnsTag = Tag.of("destination_namespace", destinationNamespace);
+                Tag dsTag = Tag.of(DESTINATION_SERVICE, destinationService);
+                Tag dnsTag = Tag.of(DESTINATION_NAMESPACE, destinationNamespace);
                 return Arrays.asList(RestTemplateExchangeTags.method(request), dsTag, dnsTag,
-                    RestTemplateExchangeTags.status(response), RestTemplateExchangeTags.clientName(request));
+                    RestTemplateExchangeTags.status(response), RestTemplateExchangeTags.clientName(request),
+                    Tag.of(REQUEST_OPERATION, parser.parseClassification(request)));
             }
         };
     }
@@ -130,10 +165,11 @@ public class <%= upperProjectName %>WebClientConfig {
                     destinationService = "localhost".equalsIgnoreCase(host) ? metricTags.getSourceServiceName() : host;
                     destinationNamespace = metricTags.getSourceServiceNamespace();
                 }
-                Tag dsTag = Tag.of("destination_service", destinationService);
-                Tag dnsTag = Tag.of("destination_namespace", destinationNamespace);
+                Tag dsTag = Tag.of(DESTINATION_SERVICE, destinationService);
+                Tag dnsTag = Tag.of(DESTINATION_NAMESPACE, destinationNamespace);
                 return Arrays.asList(WebClientExchangeTags.method(request), dsTag, dnsTag,
-                    WebClientExchangeTags.status(response, new IOException("IO Exception")), WebClientExchangeTags.clientName(request));
+                    WebClientExchangeTags.status(response, new IOException("IO Exception")), WebClientExchangeTags.clientName(request),
+                    Tag.of(REQUEST_OPERATION, parser.parseClassification(request)));
             }
         };
     }

--- a/generators/create-service/templates/microservice/src/main/resources/bootstrap.yml
+++ b/generators/create-service/templates/microservice/src/main/resources/bootstrap.yml
@@ -1,12 +1,26 @@
+server:
+  port: 8080
+  names: ${MICRO_SERVICE_NAME}
 management:
-  <%_ if (tracingEnabled) { -%>
+  server:
+    port: 8080
+  endpoint:
+    info:
+      enabled: true
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
   metrics:
     tags:
-      reporter: source
-      service: ${spring.application.name}
-      namespace: <%= K8S_NAMESPACE || "#请输入 命名空间名称" %>
-      client_name: unknown
-      client_namespace: unknown
+      service: ${MICRO_SERVICE_NAME}
+      namespace: ${KUBERNETES_NAMESPACE:default_unknown}
+      client_name: ${MICRO_SERVICE_NAME:default_unknown}
+      client_namespace: ${KUBERNETES_NAMESPACE:default_unknown}
+      request_operation: default_unknown
     distribution:
       percentiles-histogram:
         http:
@@ -19,13 +33,6 @@ management:
             percentiles: 0.5,0.95,0.99
     enable:
       jvm: false
-  <%_ } -%>
-
-server:
-  port: 8080
-  names: ${MICRO_SERVICE_NAME}
-
-
 spring:
   application:
     #服务名称
@@ -77,13 +84,12 @@ spring:
       <%_ if (tracingEnabled) { -%>
       workload:
         name: ${SOURCE_WORKLOAD:default_unknown}
-        namespace: ${SOURCE_SERVICE_NAMESPACE:default_unknown}
+        namespace: ${KUBERNETES_NAMESPACE:default_unknown}
         app: ${SOURCE_APP:default_unknown}
       service:
-        name: ${spring.application.name:default_unknown}
-        namespace: ${SOURCE_SERVICE_NAMESPACE:default_unknown}
+        name: ${MICRO_SERVICE_NAME:default_unknown}
+        namespace: ${KUBERNETES_NAMESPACE:default_unknown}
       discovery:
         all-namespace: true
       <%_ } -%>
     <%_ } -%>
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-asf",
-    "version": "0.1.7-alpha.20",
+    "version": "0.1.7-alpha.23",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-asf",
-    "version": "0.1.7-alpha.20",
+    "version": "0.1.7-alpha.23",
     "description": "",
     "homepage": "",
     "author": {


### PR DESCRIPTION
1. 配置变更, 更新策略暂时为 重新启动
2. management.port 改为 management.server.port, 以修复jira 3340 微服务应用管理端口修改无效的问题
3. 把configmap中的management 配置 也 加进了打入jar包的bootstrap中, 因为二者最终是合并关系.